### PR TITLE
runtime/arm64: Simplify dispatcher

### DIFF
--- a/runtime/arm64/dispatcher.S
+++ b/runtime/arm64/dispatcher.S
@@ -108,7 +108,6 @@ _dispatcher_trampoline:
 	// Step 4: Invoke high-level dispatcher
 	// ----------------------------------------------------------
 	mov	x0, x16				// arg0: target address
-	add	x1, sp, #512			// arg1: CPU state ptr
 	bl	_dispatcher			// Call C dispatcher
 	mov	x16, x0				// Save new target
 


### PR DESCRIPTION
Simplify dispatcher by only dealing with translated code, not supervisor code.