### PR TITLE
Fix random guest stack allocation failure on Darwin

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -88,3 +88,28 @@ If you encounter a feature that isn't supported, check [COMPAT.md](COMPAT.md) fo
 * System calls
 * libc functions
 * Architecture-specific instructions
+
+## Appendix: Internals
+
+### Guest Address Space Layout (Darwin/arm64)
+
+Weave loads guest programs into a dedicated address space separate from the supervisor. The memory layout is organized as follows:
+
+| Address Range | Size | Usage |
+|---------------|------|-------|
+| (dynamic) | 8 MB | Guest stack (grows down) |
+| `0x200000000` | varies | Main executable (Mach-O base) |
+| `0x400000000+` | 4 GB each | Shared libraries |
+| `0x7FFF00000000` | ~4 GB | Shared cache (system libraries) |
+
+The stack is dynamically allocated by the kernel to avoid address conflicts with ASLR. Libraries are loaded with 4 GB spacing to accommodate large binaries and leave room for heap allocations within each library's address range.
+
+### Guest Address Space Layout (Linux/x86_64)
+
+| Address Range | Size | Usage |
+|---------------|------|-------|
+| `0x200000000` | varies | ELF executable base |
+
+### Code Cache
+
+Translated code blocks are stored in a code cache. On x86_64, the code cache starts at `0x200000000`.

--- a/sys/darwin/xnu.rs
+++ b/sys/darwin/xnu.rs
@@ -102,15 +102,14 @@ impl Task {
         // Set up guest stack with argc/argv
         // Allocate a stack region in guest address space
         let stack_size: usize = 8 * 1024 * 1024; // 8MB stack
-        let stack_base: u64 = 0x200000000; // Stack base address in guest space
 
-        // Map the stack
+        // Map the stack - let the kernel choose an available address to avoid conflicts
         let stack_ptr = unsafe {
             libc::mmap(
-                stack_base as *mut libc::c_void,
+                std::ptr::null_mut(),
                 stack_size,
                 libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
                 -1,
                 0,
             )
@@ -118,6 +117,7 @@ impl Task {
         if stack_ptr == libc::MAP_FAILED {
             panic!("Failed to allocate guest stack");
         }
+        let stack_base = stack_ptr as u64;
         debug!(
             "Allocated guest stack at 0x{:x}, size {}",
             stack_base, stack_size


### PR DESCRIPTION
The stack was using MAP_FIXED at a hardcoded address (0x200000000) which conflicted with the Mach-O executable base address. With ASLR, this caused intermittent failures when the address was already mapped.

Remove MAP_FIXED and let the kernel choose an available address. Also add an Internals appendix to MANUAL.md documenting the guest address space layout.