### PR TITLE
Fix LDR literal (PC-relative data loads) in ARM64 translator

### DIFF
--- a/runtime/arm64/assembler.rs
+++ b/runtime/arm64/assembler.rs
@@ -189,6 +189,36 @@ impl Assembler {
         self.emit(insn);
     }
 
+    /// Emits LDR Xt, [Xn] (64-bit register-indirect load).
+    pub fn emit_ldr_x(&mut self, rd: u32, rn: u32) {
+        self.emit(0xf9400000 | (rd & 0x1f) | ((rn & 0x1f) << 5));
+    }
+
+    /// Emits LDR Wt, [Xn] (32-bit register-indirect load).
+    pub fn emit_ldr_w(&mut self, rd: u32, rn: u32) {
+        self.emit(0xb9400000 | (rd & 0x1f) | ((rn & 0x1f) << 5));
+    }
+
+    /// Emits LDRSW Xt, [Xn] (sign-extending 32-bit register-indirect load).
+    pub fn emit_ldrsw(&mut self, rd: u32, rn: u32) {
+        self.emit(0xb9800000 | (rd & 0x1f) | ((rn & 0x1f) << 5));
+    }
+
+    /// Emits LDR St, [Xn] (32-bit SIMD/FP register-indirect load).
+    pub fn emit_ldr_s(&mut self, rt: u32, rn: u32) {
+        self.emit(0xbd400000 | (rt & 0x1f) | ((rn & 0x1f) << 5));
+    }
+
+    /// Emits LDR Dt, [Xn] (64-bit SIMD/FP register-indirect load).
+    pub fn emit_ldr_d(&mut self, rt: u32, rn: u32) {
+        self.emit(0xfd400000 | (rt & 0x1f) | ((rn & 0x1f) << 5));
+    }
+
+    /// Emits LDR Qt, [Xn] (128-bit SIMD/FP register-indirect load).
+    pub fn emit_ldr_q(&mut self, rt: u32, rn: u32) {
+        self.emit(0x3dc00000 | (rt & 0x1f) | ((rn & 0x1f) << 5));
+    }
+
     /// Emits a raw 32-bit instruction.
     pub fn emit(&mut self, insn: u32) {
         unsafe {

--- a/runtime/arm64/translate.rs
+++ b/runtime/arm64/translate.rs
@@ -313,16 +313,72 @@ fn translate_insn(
                         Ok(true)
                     }
                 },
+                decoder::Operation::LOADLIT(loadlit) => match loadlit {
+                    decoder::LOADLIT::LDR_Rt_ADDR_PCREL19(ldr) => {
+                        let rt = ldr.rt();
+                        let imm19 = ldr.imm19();
+                        let signed_offset = if imm19 & 0x40000 != 0 {
+                            (imm19 as i64) | (-1i64 << 19)
+                        } else {
+                            imm19 as i64
+                        };
+                        let target_addr = addr.wrapping_add((signed_offset << 2) as u64);
+                        let opc = (insn >> 30) & 0x3;
+                        block.asm.emit_ld_imm(rt, target_addr);
+                        if opc == 0 {
+                            block.asm.emit_ldr_w(rt, rt);
+                        } else {
+                            block.asm.emit_ldr_x(rt, rt);
+                        }
+                        Ok(true)
+                    }
+                    decoder::LOADLIT::LDR_Ft_ADDR_PCREL19(ldr) => {
+                        let rt = ldr.rt();
+                        let imm19 = ldr.imm19();
+                        let signed_offset = if imm19 & 0x40000 != 0 {
+                            (imm19 as i64) | (-1i64 << 19)
+                        } else {
+                            imm19 as i64
+                        };
+                        let target_addr = addr.wrapping_add((signed_offset << 2) as u64);
+                        let opc = (insn >> 30) & 0x3;
+                        // Use x17 as scratch (intra-procedure-call scratch register)
+                        block.asm.emit_ld_imm(17, target_addr);
+                        match opc {
+                            0 => block.asm.emit_ldr_s(rt, 17),
+                            1 => block.asm.emit_ldr_d(rt, 17),
+                            _ => block.asm.emit_ldr_q(rt, 17),
+                        }
+                        Ok(true)
+                    }
+                    decoder::LOADLIT::LDRSW_Rt_ADDR_PCREL19(ldr) => {
+                        let rt = ldr.rt();
+                        let imm19 = ldr.imm19();
+                        let signed_offset = if imm19 & 0x40000 != 0 {
+                            (imm19 as i64) | (-1i64 << 19)
+                        } else {
+                            imm19 as i64
+                        };
+                        let target_addr = addr.wrapping_add((signed_offset << 2) as u64);
+                        block.asm.emit_ld_imm(rt, target_addr);
+                        block.asm.emit_ldrsw(rt, rt);
+                        Ok(true)
+                    }
+                    decoder::LOADLIT::PRFM_PRFOP_ADDR_PCREL19(_) => {
+                        // Prefetch is a performance hint, not required for correctness
+                        Ok(true)
+                    }
+                },
                 _ => {
                     block.emit(insn);
                     Ok(true)
                 }
             }
         } else {
-            Err(Error::InstructionDecode(format!(
-                "Failed to decode instruction 0x{:08x} at 0x{:016x}",
-                insn, addr
-            )))
+            // Hit non-instruction data (e.g. literal pool embedded in the text
+            // section). End the block — the data lives in guest memory and is
+            // accessed by translated LDR literal sequences, not executed.
+            Ok(false)
         }
     } else {
         trace!("End of translatable region at 0x{:016x}", addr);

--- a/testing/darwin-arm64/Makefile
+++ b/testing/darwin-arm64/Makefile
@@ -5,6 +5,7 @@ TESTS += branch-indirect
 TESTS += branch-cond
 TESTS += branch-test
 TESTS += branch-pac
+TESTS += ldr-literal
 
 ASFLAGS =
 LDFLAGS =

--- a/testing/darwin-arm64/ldr-literal.S
+++ b/testing/darwin-arm64/ldr-literal.S
@@ -1,0 +1,109 @@
+# LDR literal (PC-relative data load) tests
+#
+# These tests verify that LDR literal instructions are correctly
+# translated. The translator must rewrite them because they encode
+# a PC-relative offset — if copied verbatim to the code cache, the
+# CPU would compute the target from the wrong PC and load garbage.
+
+.global _main
+
+_main:
+    # -------------------------------------------------------
+    # Test 1: LDR Xt, <label>  (64-bit integer literal load)
+    # -------------------------------------------------------
+    ldr x0, const64
+    movz x1, #0xBEEF, lsl #0
+    movk x1, #0xDEAD, lsl #16
+    movk x1, #0, lsl #32
+    movk x1, #0, lsl #48
+    cmp x0, x1
+    b.ne test_failed_1
+
+    # -------------------------------------------------------
+    # Test 2: LDR Wt, <label>  (32-bit integer literal load)
+    # -------------------------------------------------------
+    ldr w2, const32
+    movz w3, #0x4321
+    movk w3, #0x8765, lsl #16
+    cmp w2, w3
+    b.ne test_failed_2
+
+    # -------------------------------------------------------
+    # Test 3: LDRSW Xt, <label>  (sign-extending 32-bit load)
+    # -------------------------------------------------------
+    ldrsw x4, const_neg
+    # const_neg is 0xFFFFFFF0 = -16 as i32
+    # After sign-extension to 64 bits: 0xFFFFFFFFFFFFFFF0
+    movn x5, #0xF          // x5 = ~0xF = 0xFFFFFFFFFFFFFFF0
+    cmp x4, x5
+    b.ne test_failed_3
+
+    # -------------------------------------------------------
+    # Test 4: LDR St, <label>  (32-bit FP literal load)
+    #
+    # Load the float constant 2.0 (IEEE 754: 0x40000000) from
+    # a literal pool, then convert to integer and check.
+    # -------------------------------------------------------
+    ldr s0, const_float
+    fcvtzs w6, s0           // w6 = (int)2.0 = 2
+    cmp w6, #2
+    b.ne test_failed_4
+
+    # -------------------------------------------------------
+    # Test 5: LDR Dt, <label>  (64-bit FP literal load)
+    #
+    # Load the double constant 3.0 (IEEE 754: 0x4008000000000000)
+    # -------------------------------------------------------
+    ldr d1, const_double
+    fcvtzs w7, d1           // w7 = (int)3.0 = 3
+    cmp w7, #3
+    b.ne test_failed_5
+
+    # All tests passed
+    movz x0, #0
+    movz x16, #1
+    svc #0x80
+
+test_failed_1:
+    movz x0, #1
+    movz x16, #1
+    svc #0x80
+
+test_failed_2:
+    movz x0, #2
+    movz x16, #1
+    svc #0x80
+
+test_failed_3:
+    movz x0, #3
+    movz x16, #1
+    svc #0x80
+
+test_failed_4:
+    movz x0, #4
+    movz x16, #1
+    svc #0x80
+
+test_failed_5:
+    movz x0, #5
+    movz x16, #1
+    svc #0x80
+
+# -------------------------------------------------------
+# Literal pool — data embedded after the code
+# -------------------------------------------------------
+.p2align 2
+const64:
+    .quad 0xDEADBEEF
+
+const32:
+    .long 0x87654321
+
+const_neg:
+    .long 0xFFFFFFF0         // -16 as a signed 32-bit integer
+
+const_float:
+    .long 0x40000000         // 2.0f in IEEE 754
+
+const_double:
+    .quad 0x4008000000000000 // 3.0 in IEEE 754 double


### PR DESCRIPTION
LDR literal instructions encode a PC-relative offset to load data from nearby memory. The translator was copying these instructions verbatim to the code cache, causing the CPU to compute the target from the code cache PC instead of the original guest PC — loading from the wrong address.

Fix by translating LDR literal into a MOV-immediate of the absolute guest address followed by a register-indirect load. Handle all variants: integer (32/64-bit), SIMD/FP (32/64/128-bit), sign-extending word, and prefetch (dropped as a no-op).

Also fix the translator to end the block when it encounters un-decodable data (e.g. literal pools embedded in the text section) instead of panicking.