### PR TITLE
Pass environment variables (envp) to guest programs

### DIFF
--- a/main.rs
+++ b/main.rs
@@ -49,7 +49,8 @@ fn main() {
     for arg in &opts.program_args {
         argv.push(arg);
     }
-    let Err(e) = sys::execve(&opts.program, &argv);
+    let envp: Vec<String> = env::vars().map(|(k, v)| format!("{}={}", k, v)).collect();
+    let Err(e) = sys::execve(&opts.program, &argv, &envp);
     eprintln!("weave: {}", e);
     exit(1);
 }

--- a/runtime/x86/translate.rs
+++ b/runtime/x86/translate.rs
@@ -1185,24 +1185,20 @@ impl TranslatedBlock {
             // Set up guest registers and jump to translated code
             // This never returns - the guest code will eventually call exit() or
             // main() will return (triggering the sentinel detection in the dispatcher).
+            // Use explicit register bindings for argument registers so LLVM places
+            // values directly, avoiding clobbering when moving to named registers.
             std::arch::asm!(
                 "mov rsp, {rsp}",
                 "mov rbp, {rbp}",
-                "mov rdi, {rdi}",
-                "mov rsi, {rsi}",
-                "mov rdx, {rdx}",
-                "mov rcx, {rcx}",
-                "mov r8, {r8}",
-                "mov r9, {r9}",
                 "jmp {code}",
                 rsp = in(reg) rsp,
                 rbp = in(reg) rbp,
-                rdi = in(reg) rdi,
-                rsi = in(reg) rsi,
-                rdx = in(reg) rdx,
-                rcx = in(reg) rcx,
-                r8 = in(reg) r8,
-                r9 = in(reg) r9,
+                in("rdi") rdi,
+                in("rsi") rsi,
+                in("rdx") rdx,
+                in("rcx") rcx,
+                in("r8") r8,
+                in("r9") r9,
                 code = in(reg) guest_code_start,
                 options(noreturn)
             );
@@ -1240,21 +1236,15 @@ impl TranslatedBlock {
             std::arch::asm!(
                 "mov rsp, {rsp}",
                 "mov rbp, {rbp}",
-                "mov rdi, {rdi}",
-                "mov rsi, {rsi}",
-                "mov rdx, {rdx}",
-                "mov rcx, {rcx}",
-                "mov r8, {r8}",
-                "mov r9, {r9}",
                 "jmp {code}",
                 rsp = in(reg) rsp,
                 rbp = in(reg) rbp,
-                rdi = in(reg) rdi,
-                rsi = in(reg) rsi,
-                rdx = in(reg) rdx,
-                rcx = in(reg) rcx,
-                r8 = in(reg) r8,
-                r9 = in(reg) r9,
+                in("rdi") rdi,
+                in("rsi") rsi,
+                in("rdx") rdx,
+                in("rcx") rcx,
+                in("r8") r8,
+                in("r9") r9,
                 code = in(reg) guest_code_start,
                 options(noreturn)
             );

--- a/sys/darwin/xnu.rs
+++ b/sys/darwin/xnu.rs
@@ -66,6 +66,7 @@ impl Task {
         &mut self,
         path: &str,
         argv: &[&str],
+        envp: &[String],
     ) -> Result<std::convert::Infallible, crate::Error> {
         // Open and parse the Mach-O file
         let file = MappedFile::open(path).map_err(|e| exec_error(path, e))?;
@@ -133,7 +134,21 @@ impl Task {
         // Stack grows down, so start at the top of the stack
         let mut sp = stack_base + stack_size as u64;
 
-        // First, write all the argument strings and collect their addresses
+        // First, write all the environment strings and collect their addresses
+        let mut env_addrs: Vec<u64> = Vec::with_capacity(envp.len());
+        for env_var in envp {
+            let bytes = env_var.as_bytes();
+            sp -= (bytes.len() + 1) as u64; // +1 for null terminator
+            // Align to 8 bytes
+            sp &= !7;
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), sp as *mut u8, bytes.len());
+                *((sp + bytes.len() as u64) as *mut u8) = 0; // null terminator
+            }
+            env_addrs.push(sp);
+        }
+
+        // Write all the argument strings and collect their addresses
         let mut arg_addrs: Vec<u64> = Vec::with_capacity(argv.len());
         for arg in argv {
             let bytes = arg.as_bytes();
@@ -150,6 +165,32 @@ impl Task {
 
         // Align stack to 16 bytes
         sp &= !15;
+
+        // The macOS ABI requires SP to be 16-byte aligned when _start runs.
+        // Total 8-byte entries: 1 (argc) + argc + 1 (argv NULL) + envp_count + 1 (envp NULL)
+        // If odd, we need one padding entry to maintain 16-byte alignment.
+        let total_entries = 1 + argv.len() + 1 + envp.len() + 1;
+        if total_entries % 2 != 0 {
+            sp -= 8;
+            unsafe {
+                *(sp as *mut u64) = 0;
+            }
+        }
+
+        // Push NULL terminator for envp array
+        sp -= 8;
+        unsafe {
+            *(sp as *mut u64) = 0;
+        }
+
+        // Push envp pointers in reverse order
+        for addr in env_addrs.iter().rev() {
+            sp -= 8;
+            unsafe {
+                *(sp as *mut u64) = *addr;
+            }
+        }
+        let envp_ptr = sp;
 
         // Push NULL terminator for argv array
         sp -= 8;
@@ -172,9 +213,6 @@ impl Task {
             *(sp as *mut u64) = argv.len() as u64;
         }
 
-        // Align to 16 bytes for ABI compliance
-        sp &= !15;
-
         debug!(
             "Guest stack: sp=0x{:x}, argc={}, argv=0x{:x}",
             sp,
@@ -183,9 +221,10 @@ impl Task {
         );
 
         // Set up initial register state for main()
-        // On ARM64: x0 = argc, x1 = argv
+        // On ARM64: x0 = argc, x1 = argv, x2 = envp
         self.context.state.regs[0] = argv.len() as u64; // argc
         self.context.state.regs[1] = argv_ptr; // argv
+        self.context.state.regs[2] = envp_ptr; // envp
         self.context.state.regs[29] = sp; // frame pointer
         // Note: sp is set dynamically when guest code runs, not stored in regs
 
@@ -195,9 +234,10 @@ impl Task {
             text_start, text_end
         );
         trace!(
-            "Initial state: x0(argc)={}, x1(argv)=0x{:x}",
+            "Initial state: x0(argc)={}, x1(argv)=0x{:x}, x2(envp)=0x{:x}",
             argv.len(),
-            argv_ptr
+            argv_ptr,
+            envp_ptr,
         );
 
         // Run the program - this never returns
@@ -214,9 +254,13 @@ impl Task {
 ///
 /// This function loads a Mach-O binary, processes dynamic linking requirements, sets up the
 /// task state, and begins execution. It never returns.
-pub fn execve(path: &str, argv: &[&str]) -> Result<std::convert::Infallible, crate::Error> {
+pub fn execve(
+    path: &str,
+    argv: &[&str],
+    envp: &[String],
+) -> Result<std::convert::Infallible, crate::Error> {
     let task = unsafe { &mut *get_current_task() };
-    task.execve(path, argv)
+    task.execve(path, argv, envp)
 }
 
 const SYSCALL_EXIT: u32 = 1;

--- a/sys/linux/glibc.rs
+++ b/sys/linux/glibc.rs
@@ -42,9 +42,11 @@ pub extern "C" fn libc_start_main(
 
     // Set up CPU state for main(argc, argv, envp)
     // x86-64 calling convention: rdi, rsi, rdx for first 3 args
+    // envp starts right after the argv NULL terminator: &argv[argc + 1]
+    let envp = unsafe { argv.add(argc as usize + 1) };
     task.context.state.regs[crate::runtime::x86::REG_RDI] = argc as u64; // RDI: argc
     task.context.state.regs[crate::runtime::x86::REG_RSI] = argv as u64; // RSI: argv
-    task.context.state.regs[crate::runtime::x86::REG_RDX] = 0; // RDX: envp (NULL)
+    task.context.state.regs[crate::runtime::x86::REG_RDX] = envp as u64; // RDX: envp
 
     // Push a sentinel return address (0) onto the guest stack
     // When main() returns, the dispatcher will see target_addr == 0 and call exit()

--- a/sys/linux/kernel.rs
+++ b/sys/linux/kernel.rs
@@ -68,6 +68,7 @@ impl Task {
         &mut self,
         path: &str,
         argv: &[&str],
+        envp: &[String],
     ) -> Result<std::convert::Infallible, crate::Error> {
         // Open and parse the ELF file
         let file = MappedFile::open(path).map_err(|e| exec_error(path, e))?;
@@ -175,7 +176,21 @@ impl Task {
         // Stack grows down, so start at the top of the stack
         let mut sp = stack_base + stack_size as u64;
 
-        // First, write all the argument strings and collect their addresses
+        // First, write all the environment strings and collect their addresses
+        let mut env_addrs: Vec<u64> = Vec::with_capacity(envp.len());
+        for env_var in envp {
+            let bytes = env_var.as_bytes();
+            sp -= (bytes.len() + 1) as u64; // +1 for null terminator
+            // Align to 8 bytes
+            sp &= !7;
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), sp as *mut u8, bytes.len());
+                *((sp + bytes.len() as u64) as *mut u8) = 0; // null terminator
+            }
+            env_addrs.push(sp);
+        }
+
+        // Write all the argument strings and collect their addresses
         let mut arg_addrs: Vec<u64> = Vec::with_capacity(argv.len());
         for arg in argv {
             let bytes = arg.as_bytes();
@@ -193,10 +208,29 @@ impl Task {
         // Align stack to 16 bytes
         sp &= !15;
 
-        // Push NULL terminator for envp array (no environment variables)
+        // The Linux ABI requires SP to be 16-byte aligned when _start runs.
+        // Total 8-byte entries: 1 (argc) + argc + 1 (argv NULL) + envp_count + 1 (envp NULL)
+        // If odd, we need one padding entry to maintain 16-byte alignment.
+        let total_entries = 1 + argv.len() + 1 + envp.len() + 1;
+        if total_entries % 2 != 0 {
+            sp -= 8;
+            unsafe {
+                *(sp as *mut u64) = 0;
+            }
+        }
+
+        // Push NULL terminator for envp array
         sp -= 8;
         unsafe {
             *(sp as *mut u64) = 0;
+        }
+
+        // Push envp pointers in reverse order
+        for addr in env_addrs.iter().rev() {
+            sp -= 8;
+            unsafe {
+                *(sp as *mut u64) = *addr;
+            }
         }
 
         // Push NULL terminator for argv array
@@ -219,9 +253,6 @@ impl Task {
         unsafe {
             *(sp as *mut u64) = argv.len() as u64;
         }
-
-        // Align to 16 bytes for ABI compliance
-        sp &= !15;
 
         debug!(
             "Guest stack: sp=0x{:x}, argc={}, argv=0x{:x}",
@@ -252,9 +283,13 @@ impl Task {
 }
 
 /// Execute a file
-pub fn execve(path: &str, argv: &[&str]) -> Result<std::convert::Infallible, crate::Error> {
+pub fn execve(
+    path: &str,
+    argv: &[&str],
+    envp: &[String],
+) -> Result<std::convert::Infallible, crate::Error> {
     let task = unsafe { &mut *get_current_task() };
-    task.execve(path, argv)
+    task.execve(path, argv, envp)
 }
 
 /// Set up Thread-Local Storage for the guest binary.

--- a/testing/conformance/libc/Makefile
+++ b/testing/conformance/libc/Makefile
@@ -9,6 +9,7 @@ TESTS += math
 TESTS += stdio
 TESTS += string
 TESTS += memory
+TESTS += envp
 
 ASFLAGS = -fPIE
 LDFLAGS = -pie

--- a/testing/conformance/libc/envp.c
+++ b/testing/conformance/libc/envp.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[], char *envp[])
+{
+	unsigned long envp_val = (unsigned long)envp;
+
+	/* envp must not be a small integer (indicates register/stack bug) */
+	if (envp_val > 0 && envp_val < 4096) {
+		fprintf(stderr, "envp has invalid value %p\n", (void *)envp);
+		return 1;
+	}
+
+	/* envp must not be NULL */
+	if (envp == (char **)0) {
+		fprintf(stderr, "envp is NULL\n");
+		return 1;
+	}
+
+	/* envp must contain at least one entry */
+	if (envp[0] == (char *)0) {
+		fprintf(stderr, "envp is empty\n");
+		return 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Collect the supervisor's environment variables and pass them through to the guest via the standard argc/argv/envp stack layout on both Linux (x86-64) and Darwin (ARM64). Also fix x86 inline asm to use explicit register bindings, avoiding clobbering when setting up argument registers.